### PR TITLE
删除多余代码

### DIFF
--- a/Assets/ToLua/Core/LuaState.cs
+++ b/Assets/ToLua/Core/LuaState.cs
@@ -92,7 +92,6 @@ namespace LuaInterface
             LuaException.Init();     
             L = LuaDLL.luaL_newstate();                                                                        
             LuaDLL.tolua_openlibs(L);
-            LuaDLL.tolua_openint64(L);    
             LuaStatic.OpenLibs(L);                                                                                                  
             stateMap.Add(L, this);                       
             OpenBaseLibs();            


### PR DESCRIPTION
 LuaDLL.tolua_openint64(L);  在           LuaDLL.tolua_openlibs(L); 中已经注册了。