### PR TITLE
support raw function export

### DIFF
--- a/Assets/ToLua/Editor/ToLuaExport.cs
+++ b/Assets/ToLua/Editor/ToLuaExport.cs
@@ -500,7 +500,14 @@ public static class ToLuaExport
             {
                 if (!m.Name.Contains("op_"))
                 {
-                    sb.AppendFormat("\t\tL.RegFunction(\"{0}\", {1});\r\n", m.Name, m.Name == "Register" ? "_Register" : m.Name);
+                    if (m.GetCustomAttributes(typeof(MonoPInvokeCallbackAttribute), false).Length != 0)
+                    {
+                        sb.AppendFormat("\t\tL.RegFunction(\"{0}\", {1}.{0});\r\n", m.Name, type.FullName);
+                    }
+                    else
+                    {
+                        sb.AppendFormat("\t\tL.RegFunction(\"{0}\", {1});\r\n", m.Name, m.Name == "Register" ? "_Register" : m.Name);
+                    }
                 }
 
                 nameCounter[m.Name] = 1;
@@ -726,6 +733,10 @@ public static class ToLuaExport
 
     static void GenFunction(MethodInfo m)
     {
+        if (m.GetCustomAttributes(typeof(MonoPInvokeCallbackAttribute), false).Length != 0)
+        {
+            return;
+        }
         sb.AppendLineEx("\r\n\t[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]");
         sb.AppendFormat("\tstatic int {0}(IntPtr L)\r\n", m.Name == "Register" ? "_Register" : m.Name);
         sb.AppendLineEx("\t{");


### PR DESCRIPTION
如果导出的类包含了已经标记为 MonoPInvokeCallbackAttribute 的方法, 那么就直接生成导出, 不再生成包装函数.
(少数情况下存在需要写底层函数的可能性)