### PR TITLE
fix LuaBinder.cs about wrapregister

### DIFF
--- a/Assets/ToLua/Editor/ToLuaMenu.cs
+++ b/Assets/ToLua/Editor/ToLuaMenu.cs
@@ -214,7 +214,6 @@ public static class ToLuaMenu
 
     static void AutoAddBaseType(BindType bt, bool beDropBaseType)
     {
-
         Type t = bt.baseType;
 
         if (t == null)

--- a/Assets/ToLua/Editor/ToLuaMenu.cs
+++ b/Assets/ToLua/Editor/ToLuaMenu.cs
@@ -214,13 +214,14 @@ public static class ToLuaMenu
 
     static void AutoAddBaseType(BindType bt, bool beDropBaseType)
     {
+
         Type t = bt.baseType;
 
         if (t == null)
         {
             return;
         }
-
+       
         if (t.IsInterface)
         {
             Debugger.LogWarning("{0} has a base type {1} is Interface, use SetBaseType to jump it", bt.name, t.FullName);
@@ -271,7 +272,6 @@ public static class ToLuaMenu
     static BindType[] GenBindTypes(BindType[] list, bool beDropBaseType = true)
     {                
         allTypes = new List<BindType>(list);
-
         for (int i = 0; i < list.Length; i++)
         {            
             if (dropType.IndexOf(list[i].type) >= 0)
@@ -292,6 +292,18 @@ public static class ToLuaMenu
             }
             
             AutoAddBaseType(list[i], beDropBaseType);
+        }
+
+        for (int i = 0; i < allTypes.Count; i++)
+        {
+            var cur = allTypes[i];
+            for (int j = i + 1; j < allTypes.Count; j++)
+            {
+                if (cur.type == allTypes[j].type)
+                {
+                    allTypes.RemoveAt(j--);
+                }
+            }
         }
 
         return allTypes.ToArray();

--- a/Assets/ToLua/Editor/ToLuaMenu.cs
+++ b/Assets/ToLua/Editor/ToLuaMenu.cs
@@ -475,22 +475,52 @@ public static class ToLuaMenu
 
         for (int j = 0; j < ns.Length; j++)
         {
-            //pos变量
-            ToLuaNode<string> node = tree.Find((_t) => { return _t == ns[j]; }, j);
+            var nodes = tree.Find((_t) => { return _t == ns[j]; }, j);
 
-            if (node == null)
+            if (nodes.Count == 0)
             {
-                node = new ToLuaNode<string>();
+                var node = new ToLuaNode<string>();
                 node.value = ns[j];
                 parent.childs.Add(node);
                 node.parent = parent;
-                //加入pos跟root里的pos比较，只有位置相同才是统一命名空间节点
                 node.layer = j;
                 parent = node;
             }
             else
             {
-                parent = node;
+                var flag = false;
+                for (int i = 0; i < nodes.Count; i++)
+                {
+                    var count = j;
+                    var nodecopy = nodes[i];
+                    while (nodecopy.parent != null)
+                    {
+                        nodecopy = nodecopy.parent;
+                        if (nodecopy.value != null && nodecopy.value != ns[--count])
+                        {
+                            break;
+                        }
+                    }
+                    if (count == 0)
+                    {
+                        flag = true;
+                        break;
+                    }
+                }
+
+                if (!flag)
+                {
+                    var nnode = new ToLuaNode<string>();
+                    nnode.value = ns[j];
+                    nnode.layer = j;
+                    nnode.parent = parent;
+                    parent.childs.Add(nnode);
+                    parent = nnode;
+                }
+                else
+                {
+                    parent = nodes[0];
+                }
             }
         }
     }

--- a/Assets/ToLua/Editor/ToLuaTree.cs
+++ b/Assets/ToLua/Editor/ToLuaTree.cs
@@ -35,37 +35,32 @@ public class ToLuaNode<T>
 public class ToLuaTree<T> 
 {       
     public ToLuaNode<T> _root = null;
+    private List<ToLuaNode<T>> _list = null;
 
     public ToLuaTree()
     {
         _root = new ToLuaNode<T>();
+        _list = new List<ToLuaNode<T>>();
     }
 
     //加入pos跟root里的pos比较，只有位置相同才是统一命名空间节点
-    ToLuaNode<T> FindParent(List<ToLuaNode<T>> root, Predicate<T> match, int layer)
+    void FindParent(List<ToLuaNode<T>> list, List<ToLuaNode<T>> root, Predicate<T> match, int layer)
     {
-        if (root == null)
+        if (list == null || root == null)
         {
-            return null;
+            return;
         }
 
         for (int i = 0; i < root.Count; i++)
         {
-            //加入pos跟root里的pos比较，只有位置相同才是统一命名空间节点
+            // 加入layer跟root里的pos比较，只有位置相同才是统一命名空间节点
             if (match(root[i].value) && root[i].layer == layer)
             {
-                return root[i];
+                list.Add(root[i]);
             }
 
-            ToLuaNode<T> node = FindParent(root[i].childs, match, layer);
-
-            if (node != null)
-            {
-                return node;
-            }
+            FindParent(list, root[i].childs, match, layer);
         }
-
-        return null;
     }
 
     /*public void BreadthFirstTraversal(Action<ToLuaNode<T>> action)
@@ -106,9 +101,11 @@ public class ToLuaTree<T>
     }
 
     //只有位置相同才是统一命名空间节点
-    public ToLuaNode<T> Find(Predicate<T> match, int layer)
+    public List<ToLuaNode<T>> Find(Predicate<T> match, int layer)
     {
-        return FindParent(_root.childs, match, layer);
+        _list.Clear();
+        FindParent(_list, _root.childs, match, layer);
+        return _list;
     }
 
     public ToLuaNode<T> GetRoot()


### PR DESCRIPTION
修正LuaBinder.cs文件在 存在多级命名空间 子命名空间相同如A.B.F/A.C.F/A.C/A.D.B时，并且有多个或者重复注册文件时的WrapRegister问题