### PR TITLE
事件移除逻辑在call最后执行

### DIFF
--- a/Assets/ToLua/Lua/event.lua
+++ b/Assets/ToLua/Lua/event.lua
@@ -147,17 +147,6 @@ _event.__call = function(self, ...)
 	local _rmList = self.rmList
 	self.lock = true	
 
-	for _, v in ilist(_rmList) do					
-		for i, item in ilist(_list) do							
-			if v.func == item.func and v.obj == item.obj then
-				_list:remove(i)
-				break
-			end 
-		end
-	end
-
-	_rmList:clear()
-
 	for i, f in ilist(_list) do								
 		local flag, msg = f(...)
 		
@@ -169,6 +158,17 @@ _event.__call = function(self, ...)
 			error(msg)				
 		end
 	end
+
+	for _, v in ilist(_rmList) do					
+		for i, item in ilist(_list) do							
+			if v.func == item.func and v.obj == item.obj then
+				_list:remove(i)
+				break
+			end 
+		end
+	end
+
+	_rmList:clear()
 
 	self.lock = false			
 end


### PR DESCRIPTION
BUG:
```lua
local evt = event('test', false)
local func1 = function()
    print('111')
end
local func2 = function()
    print('222')
    evt:Remove(func1)
end

evt:Add(func2)
evt()
evt:Add(func1)
evt()
```

func1在第二次执行evt()时被会干掉，导致func1没注册成功