### PR TITLE
尝试修正Delegate无法真正移除绑定在上面的LuaFunction的问题

### DIFF
--- a/Assets/Source/Generate/DelegateFactory.cs
+++ b/Assets/Source/Generate/DelegateFactory.cs
@@ -36,13 +36,19 @@ public static class DelegateFactory
             WeakReference luaDelegateWeakRef = null;
             if (!luaDelegateDict.TryGetValue(luaFunctionRef, out luaDelegateWeakRef) || luaDelegateWeakRef == null || !luaDelegateWeakRef.IsAlive)
             {
-                luaDelegateWeakRef = new WeakReference(create(func, null, false));
+                Delegate d = create(func, null, false);
+                luaDelegateWeakRef = new WeakReference(d.Target);
                 luaDelegateDict[luaFunctionRef] = luaDelegateWeakRef;
+                return d;
             }
 
-            return luaDelegateWeakRef.Target as Delegate;
+            LuaDelegate luaDelegate = luaDelegateWeakRef.Target as LuaDelegate;
+            if (luaDelegate.self == null)
+                return Delegate.CreateDelegate(t, luaDelegate, "Call");
+            else
+                return Delegate.CreateDelegate(t, luaDelegate, "CallWithSelf");
         }
-        
+
         return create(func, null, false);        
     }
 

--- a/Assets/ToLua/Editor/ToLuaExport.cs
+++ b/Assets/ToLua/Editor/ToLuaExport.cs
@@ -3254,6 +3254,19 @@ public static class ToLuaExport
         {
             throw new LuaException(string.Format(""Delegate {0} not register"", LuaMisc.GetTypeName(t)));            
         }
+
+        if (func != null)
+        {
+            int luaFunctionRef = func.GetReference();
+            WeakReference luaDelegateWeakRef = null;
+            if (!luaDelegateDict.TryGetValue(luaFunctionRef, out luaDelegateWeakRef) || luaDelegateWeakRef == null || !luaDelegateWeakRef.IsAlive)
+            {
+                luaDelegateWeakRef = new WeakReference(create(func, null, false));
+                luaDelegateDict[luaFunctionRef] = luaDelegateWeakRef;
+            }
+
+            return luaDelegateWeakRef.Target as Delegate;
+        }
         
         return create(func, null, false);        
     }
@@ -3440,6 +3453,7 @@ public static class ToLuaExport
         sb.Append("{\r\n");        
         sb.Append("\tpublic delegate Delegate DelegateValue(LuaFunction func, LuaTable self, bool flag);\r\n");
         sb.Append("\tpublic static Dictionary<Type, DelegateValue> dict = new Dictionary<Type, DelegateValue>();\r\n");
+        sb.Append("\tpublic static Dictionary<int, WeakReference> luaDelegateDict = new Dictionary<int, WeakReference>();\r\n");
         sb.AppendLineEx();
         sb.Append("\tstatic DelegateFactory()\r\n");
         sb.Append("\t{\r\n");

--- a/Assets/ToLua/Editor/ToLuaExport.cs
+++ b/Assets/ToLua/Editor/ToLuaExport.cs
@@ -3261,11 +3261,17 @@ public static class ToLuaExport
             WeakReference luaDelegateWeakRef = null;
             if (!luaDelegateDict.TryGetValue(luaFunctionRef, out luaDelegateWeakRef) || luaDelegateWeakRef == null || !luaDelegateWeakRef.IsAlive)
             {
-                luaDelegateWeakRef = new WeakReference(create(func, null, false));
+                Delegate d = create(func, null, false);
+                luaDelegateWeakRef = new WeakReference(d.Target);
                 luaDelegateDict[luaFunctionRef] = luaDelegateWeakRef;
+                return d;
             }
 
-            return luaDelegateWeakRef.Target as Delegate;
+            LuaDelegate luaDelegate = luaDelegateWeakRef.Target as LuaDelegate;
+            if (luaDelegate.self == null)
+                return Delegate.CreateDelegate(t, luaDelegate, 'Call');
+            else
+                return Delegate.CreateDelegate(t, luaDelegate, 'CallWithSelf');
         }
         
         return create(func, null, false);        

--- a/Assets/ToLua/Editor/ToLuaExport.cs
+++ b/Assets/ToLua/Editor/ToLuaExport.cs
@@ -3269,9 +3269,9 @@ public static class ToLuaExport
 
             LuaDelegate luaDelegate = luaDelegateWeakRef.Target as LuaDelegate;
             if (luaDelegate.self == null)
-                return Delegate.CreateDelegate(t, luaDelegate, 'Call');
+                return Delegate.CreateDelegate(t, luaDelegate, ""Call"");
             else
-                return Delegate.CreateDelegate(t, luaDelegate, 'CallWithSelf');
+                return Delegate.CreateDelegate(t, luaDelegate, ""CallWithSelf"");
         }
         
         return create(func, null, false);        


### PR DESCRIPTION
尝试修正LuaFunction传进C#端逻辑，并wrap成Delegate时，每次都创建新的Delegate，导致部分逻辑中，移除Delegate上绑定的LuaFunction出错的问题（移除的不是原Delegate）