### PR TITLE
修正因gc时机不可控导致Wrap LuaFunction的Delegate生成出错的BUG

### DIFF
--- a/Assets/Source/Generate/DelegateFactory.cs
+++ b/Assets/Source/Generate/DelegateFactory.cs
@@ -32,23 +32,32 @@ public static class DelegateFactory
 
         if (func != null)
         {
-            int luaFunctionRef = func.GetReference();
+            bool bCachedDelegateValid = false;
+            LuaDelegate luaDelegate = null;
             WeakReference luaDelegateWeakRef = null;
-            if (!luaDelegateDict.TryGetValue(luaFunctionRef, out luaDelegateWeakRef) || luaDelegateWeakRef == null || !luaDelegateWeakRef.IsAlive)
+            int luaFunctionRef = func.GetReference();
+
+            if (luaDelegateDict.TryGetValue(luaFunctionRef, out luaDelegateWeakRef) 
+                && luaDelegateWeakRef.IsAlive)
+            {
+                luaDelegate = luaDelegateWeakRef.Target as LuaDelegate;
+                if (luaDelegate.func.IsAlive())
+                    bCachedDelegateValid = true;
+            }
+
+            if (!bCachedDelegateValid)
             {
                 Delegate d = create(func, null, false);
-                luaDelegateWeakRef = new WeakReference(d.Target);
-                luaDelegateDict[luaFunctionRef] = luaDelegateWeakRef;
+                luaDelegateDict[luaFunctionRef] = new WeakReference(d.Target);
                 return d;
             }
 
-            LuaDelegate luaDelegate = luaDelegateWeakRef.Target as LuaDelegate;
             if (luaDelegate.self == null)
                 return Delegate.CreateDelegate(t, luaDelegate, "Call");
             else
                 return Delegate.CreateDelegate(t, luaDelegate, "CallWithSelf");
         }
-
+        
         return create(func, null, false);        
     }
 


### PR DESCRIPTION
修正LuaFunction尚未完全gc掉的情况下，又有新的LuaFunction占用相同的全局的reference之后，生成Delegate出错的BUG