### PR TITLE
增加一个向上转型

### DIFF
--- a/Assets/ToLua/Core/LuaState.cs
+++ b/Assets/ToLua/Core/LuaState.cs
@@ -1752,7 +1752,11 @@ namespace LuaInterface
         public int GetMetaReference(Type t)
         {
             int reference = -1;
-            metaMap.TryGetValue(t, out reference);
+            while (t != null && !metaMap.TryGetValue(t, out reference))
+            {
+                t = t.BaseType;
+            }
+
             return reference;
         }
 

--- a/Assets/ToLua/Core/TypeChecker.cs
+++ b/Assets/ToLua/Core/TypeChecker.cs
@@ -175,7 +175,7 @@ namespace LuaInterface
                 case LuaTypes.LUA_TBOOLEAN:
                     return t == typeof(bool);
                 case LuaTypes.LUA_TFUNCTION:
-                    return t == typeof(LuaFunction);                            
+                    return t == typeof(LuaFunction) || t.IsSubclassOf(typeof(System.Delegate));                         
                 case LuaTypes.LUA_TTABLE:
                     return IsUserTable(L, t, pos);
                 case LuaTypes.LUA_TLIGHTUSERDATA:


### PR DESCRIPTION
c# 里面实现了一个子类但是不希望绑定给Lua，只绑定给了Lua父类
如果通过某个接口返回子类对象给Lua，是没有办法正常使用的，因为类型检查不通过。
调整了一下类型检查的地方。