### PR TITLE
修正LuaState清理过后，TypeTraits缓存的静态metaref没有正确清理，从而导致新的LuaState环境metareference错误的BUG

### DIFF
--- a/Assets/ToLua/Core/TypeTraits.cs
+++ b/Assets/ToLua/Core/TypeTraits.cs
@@ -34,7 +34,6 @@ namespace LuaInterface
 
         static string typeName = string.Empty;                
         static int nilType = -1;
-        static int metaref = -1;
 
         static public void Init(Func<IntPtr, int, bool> check)
         {            
@@ -56,13 +55,7 @@ namespace LuaInterface
 
         static public int GetLuaReference(IntPtr L)
         {
-            if (metaref > 0)
-            {                
-                return metaref;
-            }
-
-            metaref = LuaStatic.GetMetaReference(L, type);
-            return metaref;
+            return LuaStatic.GetMetaReference(L, type);
         }   
 
         static bool DefaultCheck(IntPtr L, int pos)


### PR DESCRIPTION
尝试过缓存IntPtr来“重置”缓存的静态reference，未果。单State下用WeakReference缓存LuaState来免去一次Hash查找。多State下继续用hash查找