### PR TITLE
修复由于指针类型不匹配导致在il2cpp下 可能导致栈空间内的变量被错误覆写的问题

### DIFF
--- a/Assets/ToLua/Core/LuaDLL.cs
+++ b/Assets/ToLua/Core/LuaDLL.cs
@@ -328,8 +328,11 @@ namespace LuaInterface
         }
 
         public static IntPtr lua_tolstring(IntPtr luaState, int index, out int strLen)               //[-0, +0, m]
-        {            
-            return tolua_tolstring(luaState, index, out strLen);
+        {
+            UIntPtr crossPlatformUInt;
+            IntPtr ret = tolua_tolstring(luaState, index, out crossPlatformUInt);
+            strLen = (int)crossPlatformUInt.ToUInt32();
+            return ret;
         }
 
         public static int lua_objlen(IntPtr luaState, int idx)
@@ -589,8 +592,9 @@ namespace LuaInterface
 
         public static string lua_tostring(IntPtr luaState, int index)
         {
-            int len = 0;
-            IntPtr str = tolua_tolstring(luaState, index, out len);
+            UIntPtr crossPlatformUInt;
+            IntPtr str = tolua_tolstring(luaState, index, out crossPlatformUInt);
+            int len = (int)crossPlatformUInt.ToUInt32();
 
             if (str != IntPtr.Zero)
             {
@@ -708,7 +712,9 @@ namespace LuaInterface
 
         public static string luaL_checklstring(IntPtr L, int numArg, out int len)
         {
-            IntPtr str = tolua_tolstring(L, numArg, out len);
+            UIntPtr crossPlatformUInt;
+            IntPtr str = tolua_tolstring(L, numArg, out crossPlatformUInt);
+            len = (int)crossPlatformUInt.ToUInt32();
 
             if (str == IntPtr.Zero)
             {
@@ -1169,7 +1175,7 @@ namespace LuaInterface
         public static extern int tolua_tointeger(IntPtr luaState, int idx);
 
         [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr tolua_tolstring(IntPtr luaState, int index, out int strLen);
+        public static extern IntPtr tolua_tolstring(IntPtr luaState, int index, out UIntPtr strLen);
 
         [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
         public static extern void tolua_pushlstring(IntPtr luaState, byte[] str, int size);

--- a/Assets/ToLua/Core/LuaStatePtr.cs
+++ b/Assets/ToLua/Core/LuaStatePtr.cs
@@ -221,7 +221,10 @@ namespace LuaInterface
 
         public IntPtr LuaToLString(int index, out int len)
         {
-            return LuaDLL.tolua_tolstring(L, index, out len);
+            UIntPtr crossPlatformUInt;
+            IntPtr ret = LuaDLL.tolua_tolstring(L, index, out crossPlatformUInt);
+            len = (int)crossPlatformUInt.ToUInt32();
+            return ret;
         }
 
         public IntPtr LuaToCFunction(int idx)

--- a/Assets/ToLua/Core/ToLua.cs
+++ b/Assets/ToLua/Core/ToLua.cs
@@ -1319,8 +1319,10 @@ namespace LuaInterface
                 }
                 else if (t == typeof(LuaByteBuffer))
                 {
-                    int len = 0;
-                    IntPtr source = LuaDLL.tolua_tolstring(L, stackPos, out len);
+                    UIntPtr crossPlatformUInt;
+                    IntPtr source = LuaDLL.tolua_tolstring(L, stackPos, out crossPlatformUInt);
+                    int len = (int)crossPlatformUInt.ToUInt32();
+
                     return new LuaByteBuffer(source, len);
                 }
                 else if (t == typeof(Vector3))


### PR DESCRIPTION
原本len的定义是 int, 而lua runtime中是 size_t,  size_t是平台相关的类型, 即32位下是int, 64位下是long
向32位指针写入64位值后会导致后4个字节被覆写成0
因此改成UIntPtr,  指针含义与size_t相同