### PR TITLE
【Fix:build assetbundle error】修复Unity2018.2输出assetbundle包报错。解决方式：过滤掉Qu…

### DIFF
--- a/Assets/ToLua/Editor/ToLuaExport.cs
+++ b/Assets/ToLua/Editor/ToLuaExport.cs
@@ -153,6 +153,8 @@ public static class ToLuaExport
         "TextureFormat.DXT1Crunched",
         "TextureFormat.DXT5Crunched",
         "Texture.imageContentsHash",
+        "QualitySettings.streamingMipmapsMaxLevelReduction",
+        "QualitySettings.streamingMipmapsRenderersPerFrame",
         //NGUI
         "UIInput.ProcessEvent",
         "UIWidget.showHandlesWithMoveTool",


### PR DESCRIPTION
…alitySettings 类成员属性：streamingMipmapsMaxLevelReduction，streamingMipmapsRenderersPerFrame

