### PR TITLE
Few little Optimizations for event.lua

### DIFF
--- a/Assets/ToLua/Lua/event.lua
+++ b/Assets/ToLua/Lua/event.lua
@@ -13,7 +13,10 @@ local error = error
 local print = print
 local select = select
 local traceback = tolua.traceback
-local ilist = ilist
+local list, ilist = list, ilist
+local table = table
+local ipairs = ipairs
+local unpack = unpack
 
 local _xpcall = {}
 

--- a/Assets/ToLua/Lua/event.lua
+++ b/Assets/ToLua/Lua/event.lua
@@ -11,7 +11,7 @@ local assert = assert
 local rawget = rawget
 local error = error
 local print = print
-local maxn = table.maxn
+local select = select
 local traceback = tolua.traceback
 local ilist = ilist
 
@@ -25,13 +25,13 @@ _xpcall.__call = function(self, ...)
 			return xpcall(self.func, traceback, self.obj, ...)					
 		end
 	else
-		local args = {...}
+		local nargs, args = select('#', ...), {...}
 
 		if nil == self.obj then
-			local func = function() self.func(unpack(args, 1, maxn(args))) end
+			local func = function() self.func(unpack(args, 1, nargs)) end
 			return xpcall(func, traceback)					
 		else		
-			local func = function() self.func(self.obj, unpack(args, 1, maxn(args))) end
+			local func = function() self.func(self.obj, unpack(args, 1, nargs)) end
 			return xpcall(func, traceback)
 		end
 	end	

--- a/Assets/ToLua/Lua/event.lua
+++ b/Assets/ToLua/Lua/event.lua
@@ -20,14 +20,16 @@ local unpack = unpack
 
 local _xpcall = {}
 
-_xpcall.__call = function(self, ...)	
-	if jit then
+if jit then
+	_xpcall.__call = function(self, ...)
 		if nil == self.obj then
 			return xpcall(self.func, traceback, ...)					
-		else		
+		else
 			return xpcall(self.func, traceback, self.obj, ...)					
 		end
-	else
+	end	
+else
+	_xpcall.__call = function(self, ...)
 		local nargs, args = select('#', ...), {...}
 
 		if nil == self.obj then
@@ -37,7 +39,7 @@ _xpcall.__call = function(self, ...)
 			local func = function() self.func(self.obj, unpack(args, 1, nargs)) end
 			return xpcall(func, traceback)
 		end
-	end	
+	end
 end
 
 _xpcall.__eq = function(lhs, rhs)


### PR DESCRIPTION
1. 使用 `select('#', ...)` 可以精确地获取不定参数（`...`）的个数，且不受空洞限制。且 `select` 函数就是直接返回虚拟栈上元素个数，效率非常高。相比之下 `table.maxn` 需要遍历 table 中所有元素来确定“最大的数字下标”，效率较低：
> table.maxn (table)
Returns the largest positive numerical index of the given table, or zero if the table has no positive numerical indices. (**To do its job this function does a linear traversal of the whole table**.)

2. `_xpcall.__call` 中包含对是否是 luajit 的判断，该判断可以提到函数外，改为定义两个版本的 `_xpcall.__call` 函数，从而避免每次调用时做一次（无用）的判断