### PR TITLE
Bugfix: Delete first enum element mark Obsolete.

### DIFF
--- a/Assets/ToLua/Editor/ToLuaExport.cs
+++ b/Assets/ToLua/Editor/ToLuaExport.cs
@@ -3764,7 +3764,7 @@ public static class ToLuaExport
         fields = type.GetFields(BindingFlags.GetField | BindingFlags.Public | BindingFlags.Static);
         List<FieldInfo> list = new List<FieldInfo>(fields);
 
-        for (int i = list.Count - 1; i > 0; i--)
+        for (int i = list.Count - 1; i >= 0; i--)
         {
             if (IsObsolete(list[i]))
             {


### PR DESCRIPTION
第一个元素如果是废弃的，没有删到。