### PR TITLE
Update Vector2.lua

### DIFF
--- a/Assets/ToLua/Lua/UnityEngine/Vector2.lua
+++ b/Assets/ToLua/Lua/UnityEngine/Vector2.lua
@@ -279,7 +279,7 @@ Vector2.__mul = function(a, d)
 	if type(d) == "number" then
 		return setmetatable({x = a.x * d, y = a.y * d}, Vector2)
 	else
-		return setmetatable({x = a * d.x, y = a * d.y}, Vector2)
+		return setmetatable({x = a.x * d.x, y = a.y * d.y}, Vector2)
 	end
 end
 


### PR DESCRIPTION
vector2 lua override operator * error.
cur result is  {x= table,y = table}
but {x = number,y = number} is right.