### PR TITLE
list:remove 保护处理

### DIFF
--- a/Assets/ToLua/Lua/list.lua
+++ b/Assets/ToLua/Lua/list.lua
@@ -74,6 +74,7 @@ function list:remove(iter)
 
 	local _prev = iter._prev
 	local _next = iter._next
+	if _prev._next ~= iter or _next._prev ~= iter then return end
 	_next._prev = _prev
 	_prev._next = _next
 	


### PR DESCRIPTION
list remove的一个bug，重现步骤如下：
1. new list ,push A
2. clear list
3. push B,push C
4. list remove A
这个时候，A已不在列表中了，但强行连接prev 和next 将会把list错误的设置为空列表。
在这里加一个判断，以防止此类问题发生 